### PR TITLE
inventory parsing errors 

### DIFF
--- a/twsi_evaluation.py
+++ b/twsi_evaluation.py
@@ -201,7 +201,8 @@ def map_sense_inventories(twsi_inventory_fpath, user_inventory_fpath):
     mapping_fpath = "data/Mapping_" + split(TWSI_INVENTORY)[1] + "_" + split(user_inventory_fpath)[1]
     with codecs.open(mapping_fpath, "w", "utf-8") as mapping_file:
         user_inventory = read_csv(user_inventory_fpath, sep="\t", encoding='utf8', header=None,
-            names=["word","sense_id","cluster"], dtype={'sense_id':np.unicode, 'cluster':np.unicode})
+            names=["word","sense_id","cluster"], dtype={'sense_id':np.unicode, 'cluster':np.unicode}, 
+            doublequote=False, quotechar=u"\u0000")
         user_inventory.sense_id = user_inventory.sense_id.astype(unicode)
         user_inventory.cluster = user_inventory.cluster.astype(unicode)
 
@@ -281,12 +282,14 @@ def evaluate_predicted_labels(user2twsi, lexsub_dataset_fpath, has_header=True):
 
     if has_header:
         lexsub_dataset = read_csv(lexsub_dataset_fpath, sep='\t', encoding='utf8',
-            dtype={'predict_sense_ids': np.unicode, 'gold_sense_ids': np.unicode, 'context_id': np.unicode} )
+            dtype={'predict_sense_ids': np.unicode, 'gold_sense_ids': np.unicode, 'context_id': np.unicode}, 
+            doublequote=False, quotechar=u"\u0000" )
     else:
         lexsub_dataset = read_csv(lexsub_dataset_fpath, sep='\t', encoding='utf8', header=None,
             names=["context_id","target","target_pos","target_position","gold_sense_ids","predict_sense_ids",
                    "golden_related","predict_related","context"],
-            dtype={'predict_sense_ids': np.unicode, 'gold_sense_ids': np.unicode, 'context_id': np.unicode})
+            dtype={'predict_sense_ids': np.unicode, 'gold_sense_ids': np.unicode, 'context_id': np.unicode}, 
+            doublequote=False, quotechar=u"\u0000")
     lexsub_dataset.predict_sense_ids = lexsub_dataset.predict_sense_ids.astype(unicode)
     lexsub_dataset.gold_sense_ids = lexsub_dataset.gold_sense_ids.astype(unicode)
     lexsub_dataset.context_id = lexsub_dataset.context_id.astype(unicode)

--- a/twsi_upper_bound.py
+++ b/twsi_upper_bound.py
@@ -4,7 +4,7 @@ from pandas import read_csv
 from twsi_evaluation import TWSI_INVENTORY, map_sense_inventories, calculate_evaluation_scores
 
 
-TWSI_DATASET = 'data/Dataset-TWSI-2.csv'
+# TWSI_DATASET = 'data/Dataset-TWSI-2.csv'
 
 
 def evaluate_uppper_bound(twsi_dataset_fath, user2twsi):
@@ -30,10 +30,11 @@ def evaluate_uppper_bound(twsi_dataset_fath, user2twsi):
 def main():
     parser = argparse.ArgumentParser(description='Estimation of the upper bound performance given the custom Word Sense Inventory.')
     parser.add_argument('user_inventory', metavar='sense-inventory', help='word sense inventory file, format:\n word_senseID <tab> list,of,words')
+    parser.add_argument('predictions', help='word sense disambiguation predictions in the 9 column lexical sample format.')
     args = parser.parse_args()
 
     user2twsi = map_sense_inventories(TWSI_INVENTORY, args.user_inventory)
-    correct, count = evaluate_uppper_bound(TWSI_DATASET, user2twsi)
+    correct, count = evaluate_uppper_bound(args.predictions, user2twsi)
 
     print "\nUpper Bound Results:"
     print "Correct, retrieved, nr_sentences"


### PR DESCRIPTION
1. Words in inventories may contain double quotes that serve as default escape char for pandas read_csv.
This caused parsing error while reading the wiki JoBim cluster file (even the original one). For detailed analysis see frink:/home/pelevina/experiment/intermediate/Analysis_wikijb_clusters.ipynb The proposed fix shuts down any escapechar/quoting mechanism for parsing of a _user inventory_ and a _dataset with predictions_ (related_terms may contain doublequotes too).

2. Added a parameter to evaluate an inventory on a different dataset (for now full TWSI is hardcoded in the script).

